### PR TITLE
A Node.js pixiv-api and downloader (self-recommendation).

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Sharing, suggestions and contributions are always welcome! Please take a look at
 - [DMHY](https://github.com/yaqinking/DMHY) - Easily download/auto-download torrent(s) from share.dmhy.org / acg.rip etc. sites for OS X.
 - [JComicDownloader](https://github.com/abc9070410/JComicDownloader) - A tool for downloading some comics and light novels from China.
 - [PixivUtil (Pixiv Downloader)](https://github.com/Nandaka/PixivUtil2) - Downloader and tag manager for [Pixiv](http://www.pixiv.net/).
+- [Pixiv Illust](https://github.com/HakurouKen/pixiv-illust/) - Both a downloader and a third-party nodejs api for [Pixiv](http://www.pixiv.net/). 
 - [you-get](https://github.com/soimort/you-get) - Dumb downloader that scrapes the web.
 
 ## Databases / Data Sources


### PR DESCRIPTION
I found there are already many projects about this, but most of third-party interfaces do not cover my needs. For example, I have to write some extra codes to download all my favorited illusts, or download all illusts of specific author. Meanwhile, most downloader do not provide a programming api, I have to modify the source code to do some custom downloads.
The goals of the `pixiv-illust` library are:
1. Integrate the downloader and API in one lib.
2. Provide some useful batch operations (for example, download all works favorited).
3. Only focus on download or get download info.

Please see [here](http://github.com/HakurouKen/pixiv-illust) for details if you are interested.