### PR TITLE
Replace Tachiyomi with Mihon

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,8 @@ Sharing, suggestions and contributions are always welcome! Please take a look at
 - [EhViewer](https://github.com/seven332/EhViewer) - Unofficial E-Hentai Application for Android. [中文]
 - [KonaBot](https://github.com/hkalexling/KonaBot-iOS) - iOS client for [konachan.net](http://konachan.net). [English]
 - [LNReader-Android](https://github.com/calvinaquino/LNReader-Android) - Light novel reader for android. [English]
+- [Mihon](https://github.com/mihonapp/mihon) - Free and open source manga reader for Android. [English]
 - [NineAnimator](https://github.com/SuperMarcus/NineAnimator) - Elegant, concise, and intuitive anime discovery app for iOS. [English]
-- [Tachiyomi](https://github.com/inorichi/tachiyomi) - Free and open source manga reader for Android. [English]
-
 ## Programming
 
 - [aaencoder](https://github.com/mervick/php-aaencoder) - Convert Javascript to kaomoji(顔文字). [日本語]


### PR DESCRIPTION
Tachiyomi's Development shut down after a recent copyright threat, Mihon is its fork and spiritual successor (basically same as tachiyomi but with a new name) = https://mihon.app/